### PR TITLE
Refactoring, getter for original data type, concrete exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ composer require mathematicator-core/numbers
 ## Features
 
 - **SmartNumber** - Unified safe storage for all number types with
-    an arbitrary precision.
+    an arbitrary precision. It supports comparisons.
+    - **Entity\Number** Less magic universal arbitrary precision
+    number storage with basic features.
 - **Fractions:**
     - **Entity\Fraction** - Storage for simple or compound fraction that
     can consist from numbers and other expressions.
@@ -60,6 +62,7 @@ composer require mathematicator-core/numbers
     - Fraction to human string
     - Fraction to LaTeX
     - Int to Roman and back
+- **Calculation** - simple arithmetic operations ([brick/math](https://github.com/brick/math) decorator)
 
 💡 **TIP:** You can use [mathematicator-core/tokenizer](https://github.com/mathematicator-core/tokenizer)
 for advance user input string **tokenization** or [mathematicator-core/calculator](https://github.com/mathematicator-core/calculator)

--- a/README.md
+++ b/README.md
@@ -71,19 +71,19 @@ for advance **calculations**.
 use Brick\Math\RoundingMode;
 use Mathematicator\Numbers\SmartNumber;
 
-$smartNumber = new SmartNumber(10, '80.500'); // accuracy, number
-echo $smartNumber->getDecimal(); // 80.500
-echo $smartNumber->getFraction()->getNumerator(); // 161
-echo $smartNumber->getFraction()->getDenominator(); // 2
-echo $smartNumber->getDecimal()->multipliedBy(-4); // -322.000
-echo $smartNumber->getDecimal()->multipliedBy(-4)->abs()->toInt(); // 322
-echo $smartNumber->getDecimal()->toScale(0, RoundingMode::HALF_UP); // 81
+$smartNumber = SmartNumber::of('80.500');
+echo $smartNumber->toBigDecimal(); // 80.500
+echo $smartNumber->toFraction()->getNumerator(); // 161
+echo $smartNumber->toFraction()->getDenominator(); // 2
+echo Calculation::of($smartNumber)->multipliedBy(-4); // -322.000
+echo Calculation::of($smartNumber)->multipliedBy(-4)->abs()->getResult()->toInt(); // 322
+echo $smartNumber->toBigDecimal()->toScale(0, RoundingMode::HALF_UP); // 81
 
-$smartNumber2 = new SmartNumber(10, '161/2'); // accuracy, number
-echo $smartNumber2->getHumanString(); // 161/2
-echo $smartNumber2->getHumanString()->plus(5)->equals('90.5'); // 161/2+10=90.5
-echo $smartNumber2->getLatex(); // \frac{161}{2}
-echo $smartNumber2->getDecimal();  // 80.5
+$smartNumber2 = SmartNumber::of('161/2');
+echo $smartNumber2->toHumanString(); // 161/2
+echo $smartNumber2->toHumanString()->plus(5)->equals('90.5'); // 161/2+10=90.5
+echo $smartNumber2->toLatex(); // \frac{161}{2}
+echo $smartNumber2->toBigDecimal();  // 80.5
 ```
 
 ## Recommended libraries

--- a/benchmarks/Entity/NumberBenchmark.php
+++ b/benchmarks/Entity/NumberBenchmark.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mathematicator\Numbers\Benchmarks;
+
+use Mathematicator\Numbers\Entity\Number;
+
+/**
+ * @Iterations(5)
+ */
+class NumberBenchmark
+{
+
+	/**
+	 * Only for comparison purposes
+	 *
+	 * @Revs(1000)
+	 */
+	public function benchAssignIntToStringPhp()
+	{
+		$smartNumber = (string) 158985102;
+	}
+
+
+	/**
+	 * @Revs(1000)
+	 */
+	public function benchCreateInt()
+	{
+		$smartNumber = new Number('158985102');
+	}
+
+
+	/**
+	 * @Revs(1000)
+	 */
+	public function benchCreateIntAndGetFractionNumerator()
+	{
+		$smartNumber = new Number('158985102');
+		$smartNumber->getFraction()[0]; // 158985102
+	}
+
+
+	/**
+	 * @Revs(1000)
+	 */
+	public function benchCreateIntAndGetRationalNumeratorNonSimplified()
+	{
+		$smartNumber = new Number('1482002/10');
+		$smartNumber->getRational(false)->getNumerator(); // 1482002
+	}
+
+
+	/**
+	 * @Revs(1000)
+	 */
+	public function benchCreateIntAndGetRationalNumeratorSimplified()
+	{
+		$smartNumber = new Number('158985102/10');
+		$smartNumber->getRational(true)->getNumerator(); // 741001
+	}
+}

--- a/benchmarks/Entity/NumberBenchmark.php
+++ b/benchmarks/Entity/NumberBenchmark.php
@@ -38,7 +38,7 @@ class NumberBenchmark
 	public function benchCreateIntAndGetFractionNumerator()
 	{
 		$smartNumber = new Number('158985102');
-		$smartNumber->getFraction()[0]; // 158985102
+		$smartNumber->toFraction()[0]; // 158985102
 	}
 
 
@@ -48,7 +48,7 @@ class NumberBenchmark
 	public function benchCreateIntAndGetRationalNumeratorNonSimplified()
 	{
 		$smartNumber = new Number('1482002/10');
-		$smartNumber->getRational(false)->getNumerator(); // 1482002
+		$smartNumber->toBigRational(false)->getNumerator(); // 1482002
 	}
 
 
@@ -58,6 +58,6 @@ class NumberBenchmark
 	public function benchCreateIntAndGetRationalNumeratorSimplified()
 	{
 		$smartNumber = new Number('158985102/10');
-		$smartNumber->getRational(true)->getNumerator(); // 741001
+		$smartNumber->toBigRational(true)->getNumerator(); // 741001
 	}
 }

--- a/benchmarks/SmartNumberBenchmark.php
+++ b/benchmarks/SmartNumberBenchmark.php
@@ -38,7 +38,7 @@ class SmartNumberBenchmark
 	public function benchCreateIntAndGetFractionNumerator()
 	{
 		$smartNumber = new SmartNumber('158985102');
-		$smartNumber->getFraction()[0]; // 158985102
+		$smartNumber->toFraction()[0]; // 158985102
 	}
 
 
@@ -48,7 +48,7 @@ class SmartNumberBenchmark
 	public function benchCreateIntAndGetRationalNumeratorNonSimplified()
 	{
 		$smartNumber = new SmartNumber('1482002/10');
-		$smartNumber->getRational(false)->getNumerator(); // 1482002
+		$smartNumber->toBigRational(false)->getNumerator(); // 1482002
 	}
 
 
@@ -58,6 +58,6 @@ class SmartNumberBenchmark
 	public function benchCreateIntAndGetRationalNumeratorSimplified()
 	{
 		$smartNumber = new SmartNumber('158985102/10');
-		$smartNumber->getRational(true)->getNumerator(); // 741001
+		$smartNumber->toBigRational(true)->getNumerator(); // 741001
 	}
 }

--- a/src/Calculation.php
+++ b/src/Calculation.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Mathematicator\Numbers\Entity;
+namespace Mathematicator\Numbers;
 
 
 use Brick\Math\BigDecimal;
@@ -14,7 +14,6 @@ use Brick\Math\Exception\MathException;
 use Brick\Math\RoundingMode;
 use InvalidArgumentException;
 use Mathematicator\Numbers\Exception\UnsupportedCalcOperationException;
-use Mathematicator\Numbers\SmartNumber;
 
 /**
  * Class Calculation

--- a/src/Converter/ArrayToFraction.php
+++ b/src/Converter/ArrayToFraction.php
@@ -6,7 +6,7 @@ namespace Mathematicator\Numbers\Converter;
 
 
 use Mathematicator\Numbers\Entity\Fraction;
-use Mathematicator\Numbers\Exception\NumberException;
+use Mathematicator\Numbers\Exception\NumberFormatException;
 use Nette\StaticClass;
 use Stringable;
 
@@ -17,12 +17,12 @@ final class ArrayToFraction
 	/**
 	 * @param mixed[] $fraction
 	 * @return Fraction
-	 * @throws NumberException
+	 * @throws NumberFormatException
 	 */
 	public static function convert(array $fraction): Fraction
 	{
 		if (!isset($fraction[0])) {
-			throw new NumberException('Fraction does not have numerator!');
+			throw new NumberFormatException('Fraction does not have numerator!');
 		}
 
 		$numeratorOut = self::convertPart($fraction[0]);
@@ -41,7 +41,7 @@ final class ArrayToFraction
 	 * @param Fraction $fraction
 	 * @param bool $simplify
 	 * @return mixed[]
-	 * @throws NumberException
+	 * @throws NumberFormatException
 	 */
 	public static function reverse(Fraction $fraction, bool $simplify = true)
 	{
@@ -52,7 +52,7 @@ final class ArrayToFraction
 	/**
 	 * @param mixed[]|string|Stringable|int|float|null $part
 	 * @return Fraction|string|null
-	 * @throws NumberException
+	 * @throws NumberFormatException
 	 */
 	private static function convertPart($part)
 	{

--- a/src/Converter/DecimalToFraction.php
+++ b/src/Converter/DecimalToFraction.php
@@ -8,7 +8,7 @@ namespace Mathematicator\Numbers\Converter;
 use Brick\Math\BigDecimal;
 use Brick\Math\BigNumber;
 use Mathematicator\Numbers\Entity\FractionNumbersOnly;
-use Mathematicator\Numbers\Exception\NumberException;
+use Mathematicator\Numbers\Exception\NumberFormatException;
 use Mathematicator\Numbers\Helper\FractionHelper;
 use Nette\StaticClass;
 use Stringable;
@@ -23,7 +23,7 @@ final class DecimalToFraction
 	 *
 	 * @param float|int|string|Stringable|BigNumber $decimalInput
 	 * @return FractionNumbersOnly
-	 * @throws NumberException
+	 * @throws NumberFormatException
 	 */
 	public static function convert($decimalInput): FractionNumbersOnly
 	{

--- a/src/Converter/FractionToArray.php
+++ b/src/Converter/FractionToArray.php
@@ -6,7 +6,7 @@ namespace Mathematicator\Numbers\Converter;
 
 
 use Mathematicator\Numbers\Entity\Fraction;
-use Mathematicator\Numbers\Exception\NumberException;
+use Mathematicator\Numbers\Exception\NumberFormatException;
 use Nette\StaticClass;
 
 final class FractionToArray
@@ -17,12 +17,12 @@ final class FractionToArray
 	 * @param Fraction $fraction
 	 * @param bool $simplify
 	 * @return mixed[]
-	 * @throws NumberException
+	 * @throws NumberFormatException
 	 */
 	public static function convert(Fraction $fraction, bool $simplify = true): array
 	{
 		if (!$fraction->isValid()) {
-			throw new NumberException('Fraction is not valid!');
+			throw new NumberFormatException('Fraction is not valid!');
 		}
 
 		$numeratorOut = self::convertPart($fraction->getNumerator(), false, $simplify);
@@ -35,7 +35,7 @@ final class FractionToArray
 	/**
 	 * @param mixed[] $fraction
 	 * @return Fraction
-	 * @throws NumberException
+	 * @throws NumberFormatException
 	 */
 	public static function reverse(array $fraction): Fraction
 	{
@@ -48,7 +48,7 @@ final class FractionToArray
 	 * @param bool $isDenominator
 	 * @param bool $simplify
 	 * @return string|mixed[]|null
-	 * @throws NumberException
+	 * @throws NumberFormatException
 	 */
 	private static function convertPart($part, bool $isDenominator, bool $simplify)
 	{

--- a/src/Converter/FractionToHumanString.php
+++ b/src/Converter/FractionToHumanString.php
@@ -6,7 +6,7 @@ namespace Mathematicator\Numbers\Converter;
 
 
 use Mathematicator\Numbers\Entity\Fraction;
-use Mathematicator\Numbers\Exception\NumberException;
+use Mathematicator\Numbers\Exception\NumberFormatException;
 use Mathematicator\Numbers\HumanString\MathHumanStringBuilder;
 use Mathematicator\Numbers\HumanString\MathHumanStringToolkit;
 use Nette\StaticClass;
@@ -19,12 +19,12 @@ final class FractionToHumanString
 	 * @param Fraction $fraction
 	 * @param bool $simplify Remove denominator if === 1
 	 * @return MathHumanStringBuilder
-	 * @throws NumberException
+	 * @throws NumberFormatException
 	 */
 	public static function convert(Fraction $fraction, bool $simplify = true): MathHumanStringBuilder
 	{
 		if (!$fraction->isValid()) {
-			throw new NumberException('Fraction is not valid!');
+			throw new NumberFormatException('Fraction is not valid!');
 		}
 
 		$numeratorString = self::convertPart($fraction->getNumerator(), false, $simplify);
@@ -39,7 +39,6 @@ final class FractionToHumanString
 	 * @param bool $isDenominator
 	 * @param bool $simplify Remove denominator if === 1
 	 * @return string
-	 * @throws NumberException
 	 */
 	private static function convertPart($part, bool $isDenominator, bool $simplify)
 	{

--- a/src/Converter/IntToRoman.php
+++ b/src/Converter/IntToRoman.php
@@ -8,7 +8,7 @@ namespace Mathematicator\Numbers\Converter;
 use Brick\Math\BigInteger;
 use Brick\Math\BigNumber;
 use Brick\Math\RoundingMode;
-use Mathematicator\Numbers\Exception\NumberException;
+use Mathematicator\Numbers\Exception\NumberFormatException;
 use Nette\StaticClass;
 use Stringable;
 
@@ -61,7 +61,7 @@ final class IntToRoman
 	/**
 	 * @param string $romanNumber
 	 * @return BigInteger
-	 * @throws NumberException
+	 * @throws NumberFormatException
 	 */
 	public static function reverse($romanNumber): BigInteger
 	{

--- a/src/Converter/RomanToInt.php
+++ b/src/Converter/RomanToInt.php
@@ -7,7 +7,7 @@ namespace Mathematicator\Numbers\Converter;
 
 use Brick\Math\BigInteger;
 use Brick\Math\BigNumber;
-use Mathematicator\Numbers\Exception\NumberException;
+use Mathematicator\Numbers\Exception\NumberFormatException;
 use Nette\StaticClass;
 use Nette\Utils\Strings;
 use Stringable;
@@ -42,7 +42,7 @@ final class RomanToInt
 	/**
 	 * @param string $romanNumber
 	 * @return BigInteger
-	 * @throws NumberException
+	 * @throws NumberFormatException
 	 */
 	public static function convert(string $romanNumber): BigInteger
 	{
@@ -78,12 +78,12 @@ final class RomanToInt
 	/**
 	 * @param string $romanChar
 	 * @return int
-	 * @throws NumberException
+	 * @throws NumberFormatException
 	 */
 	private static function convertSingleChar(string $romanChar): int
 	{
 		if (!isset(self::$conversionTable[$romanChar])) {
-			NumberException::invalidInput("$romanChar");
+			NumberFormatException::invalidInput("$romanChar");
 		}
 
 		return self::$conversionTable[$romanChar];

--- a/src/Entity/Calculation.php
+++ b/src/Entity/Calculation.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mathematicator\Numbers\Entity;
+
+
+use Brick\Math\BigDecimal;
+use Brick\Math\BigInteger;
+use Brick\Math\BigNumber;
+use Brick\Math\BigRational;
+use Brick\Math\Exception\DivisionByZeroException;
+use Brick\Math\Exception\MathException;
+use Brick\Math\RoundingMode;
+use InvalidArgumentException;
+use Mathematicator\Numbers\Exception\UnsupportedCalcOperationException;
+use Mathematicator\Numbers\SmartNumber;
+
+/**
+ * Class Calculation
+ * @package Mathematicator\Numbers\Entity
+ */
+class Calculation
+{
+
+	/** @var SmartNumber */
+	private $number;
+
+
+	/**
+	 * Calculation constructor.
+	 * @param SmartNumber $number
+	 */
+	public function __construct(SmartNumber $number)
+	{
+		$this->number = $number;
+	}
+
+
+	/**
+	 * @param int|float|string|BigNumber|SmartNumber $number
+	 * @return Calculation
+	 */
+	public static function of($number)
+	{
+		if ($number instanceof SmartNumber) {
+			return new self($number);
+		} else {
+			return new self(new SmartNumber($number));
+		}
+	}
+
+
+	public function getResult(): SmartNumber
+	{
+		return $this->number;
+	}
+
+
+	public function __toString()
+	{
+		return (string) $this->number;
+	}
+
+
+	/**
+	 * Returns the sum of this number and the given one.
+	 *
+	 * The result has a scale of `max($this->scale, $that->scale)`.
+	 *
+	 * @param BigNumber|int|float|string $that The number to add. Must be convertible to a BigDecimal.
+	 *
+	 * @return self The result.
+	 *
+	 * @throws MathException If the number is not valid, or is not convertible to a BigDecimal.
+	 */
+	public function plus($that): self
+	{
+		return self::of($this->getBigNumber()->plus($that));
+	}
+
+
+	/**
+	 * Returns the difference of this number and the given one.
+	 *
+	 * The result has a scale of `max($this->scale, $that->scale)`.
+	 *
+	 * @param BigNumber|int|float|string $that The number to subtract. Must be convertible to a BigDecimal.
+	 *
+	 * @return self The result.
+	 *
+	 * @throws MathException If the number is not valid, or is not convertible to a BigDecimal.
+	 */
+	public function minus($that): self
+	{
+		return self::of($this->getBigNumber()->minus($that));
+	}
+
+
+	/**
+	 * Returns the product of this number and the given one.
+	 *
+	 * The result has a scale of `$this->scale + $that->scale`.
+	 *
+	 * @param BigNumber|int|float|string $that The multiplier. Must be convertible to a BigDecimal.
+	 *
+	 * @return self The result.
+	 *
+	 * @throws MathException If the multiplier is not a valid number, or is not convertible to a BigDecimal.
+	 */
+	public function multipliedBy($that): self
+	{
+		return self::of($this->getBigNumber()->multipliedBy($that));
+	}
+
+
+	/**
+	 * Returns the result of the division of this number by the given one, at the given scale.
+	 *
+	 * @param BigNumber|int|float|string $that The divisor.
+	 * @param int|null $scale The desired scale, or null to use the scale of this number.
+	 * @param int $roundingMode An optional rounding mode.
+	 *
+	 * @return self The result.
+	 *
+	 * @throws InvalidArgumentException  If the scale or rounding mode is invalid.
+	 * @throws MathException             If the number is invalid, is zero, or rounding was necessary.
+	 */
+	public function dividedBy($that, ?int $scale = null, int $roundingMode = RoundingMode::UNNECESSARY): self
+	{
+		return self::of($this->getBigNumber()->dividedBy($that, $scale, $roundingMode));
+	}
+
+
+	/**
+	 * Returns the exact result of the division of this number by the given one.
+	 *
+	 * The scale of the result is automatically calculated to fit all the fraction digits.
+	 *
+	 * @param BigNumber|int|float|string $that The divisor. Must be convertible to a BigDecimal.
+	 *
+	 * @return self The result.
+	 *
+	 * @throws MathException If the divisor is not a valid number, is not convertible to a BigDecimal, is zero,
+	 *                       or the result yields an infinite number of digits.
+	 */
+	public function exactlyDividedBy($that): self
+	{
+		return self::of($this->getBigNumber()->toBigDecimal()->exactlyDividedBy($that));
+	}
+
+
+	/**
+	 * Returns this number exponentiated to the given value.
+	 *
+	 * @param int $exponent The exponent.
+	 *
+	 * @return self The result.
+	 *
+	 * @throws InvalidArgumentException If the exponent is not in the range 0 to 1,000,000.
+	 */
+	public function power(int $exponent): self
+	{
+		return self::of($this->getBigNumber()->power($exponent));
+	}
+
+
+	/**
+	 * Returns the quotient of the division of this number by the given one.
+	 *
+	 * @param BigNumber|int|float|string $that The divisor. Must be convertible to a BigInteger.
+	 *
+	 * @return self The result.
+	 *
+	 * @throws DivisionByZeroException If the divisor is zero.
+	 */
+	public function quotient($that): self
+	{
+		return self::of($this->getBigNumber()->quotient($that));
+	}
+
+
+	/**
+	 * Returns the remainder of the division of this number by the given one.
+	 *
+	 * The remainder, when non-zero, has the same sign as the dividend.
+	 *
+	 * @param BigNumber|int|float|string $that The divisor. Must be convertible to a BigInteger.
+	 *
+	 * @return self The result.
+	 *
+	 * @throws DivisionByZeroException If the divisor is zero.
+	 */
+	public function remainder($that): self
+	{
+		return self::of($this->getBigNumber()->remainder($that));
+	}
+
+
+	/**
+	 * Returns the absolute value of this number.
+	 *
+	 * @return self
+	 */
+	public function abs(): self
+	{
+		return self::of($this->getBigNumber()->abs());
+	}
+
+
+	/**
+	 * Returns the inverse of this number.
+	 *
+	 * @return self
+	 */
+	public function negated(): self
+	{
+		return self::of($this->getBigNumber()->negated());
+	}
+
+
+	/**
+	 * @return BigInteger|BigDecimal|BigRational
+	 * @throws UnsupportedCalcOperationException
+	 */
+	private function getBigNumber()
+	{
+		$number = $this->number->getNumber();
+
+		if (
+			$number instanceof BigInteger
+			|| $number instanceof BigDecimal
+			|| $number instanceof BigRational
+		) {
+			return $number;
+		}
+
+		throw new UnsupportedCalcOperationException();
+	}
+}

--- a/src/Entity/Fraction.php
+++ b/src/Entity/Fraction.php
@@ -8,7 +8,7 @@ namespace Mathematicator\Numbers\Entity;
 use ArrayAccess;
 use Brick\Math\BigNumber;
 use Mathematicator\Numbers\Converter\FractionToHumanString;
-use Mathematicator\Numbers\Exception\NumberException;
+use Mathematicator\Numbers\Exception\NumberFormatException;
 use Stringable;
 
 /**
@@ -77,7 +77,7 @@ class Fraction implements ArrayAccess
 	 * Returns a human string (e.g. (5/2)/1).
 	 *
 	 * @return string
-	 * @throws NumberException
+	 * @throws NumberFormatException
 	 */
 	public function __toString(): string
 	{

--- a/src/Entity/FractionArrayAccessTrait.php
+++ b/src/Entity/FractionArrayAccessTrait.php
@@ -7,7 +7,7 @@ namespace Mathematicator\Numbers\Entity;
 
 use Brick\Math\BigNumber;
 use Mathematicator\Numbers\Converter\FractionToArray;
-use Mathematicator\Numbers\Exception\NumberException;
+use Mathematicator\Numbers\Exception\NumberFormatException;
 use RuntimeException;
 use Stringable;
 
@@ -56,7 +56,7 @@ trait FractionArrayAccessTrait
 	/**
 	 * @param mixed $offset
 	 * @return mixed[]|string|null Returns recursively [string, string] or string value
-	 * @throws NumberException
+	 * @throws NumberFormatException
 	 */
 	public function offsetGet($offset)
 	{

--- a/src/Entity/FractionNumbersOnly.php
+++ b/src/Entity/FractionNumbersOnly.php
@@ -8,7 +8,7 @@ namespace Mathematicator\Numbers\Entity;
 use ArrayAccess;
 use Brick\Math\BigDecimal;
 use Brick\Math\BigNumber;
-use Mathematicator\Numbers\Exception\NumberException;
+use Mathematicator\Numbers\Exception\NumberFormatException;
 use Stringable;
 
 /**
@@ -49,7 +49,7 @@ final class FractionNumbersOnly extends Fraction implements ArrayAccess
 	/**
 	 * @param int|string|Stringable|BigNumber|FractionNumbersOnly|null $numerator
 	 * @return self
-	 * @throws NumberException
+	 * @throws NumberFormatException
 	 */
 	public function setNumerator($numerator)
 	{
@@ -57,7 +57,7 @@ final class FractionNumbersOnly extends Fraction implements ArrayAccess
 			$numerator->setParentInNumerator($this);
 			$this->numerator = $numerator;
 		} elseif ($numerator instanceof Fraction) {
-			throw new NumberException(sprintf('You can set only %s for %s compound numerator.', self::class, self::class));
+			throw new NumberFormatException(sprintf('You can set only %s for %s compound numerator.', self::class, self::class));
 		} else {
 			$this->numerator = BigDecimal::of((string) $numerator);
 		}
@@ -78,7 +78,7 @@ final class FractionNumbersOnly extends Fraction implements ArrayAccess
 	/**
 	 * @param int|string|Stringable|BigNumber|Fraction $denominator
 	 * @return FractionNumbersOnly
-	 * @throws NumberException
+	 * @throws NumberFormatException
 	 */
 	public function setDenominator($denominator): self
 	{
@@ -86,7 +86,7 @@ final class FractionNumbersOnly extends Fraction implements ArrayAccess
 			$denominator->setParentInDenominator($this);
 			$this->denominator = $denominator;
 		} elseif ($denominator instanceof Fraction) {
-			throw new NumberException(sprintf('You can set only %s for %s compound denominator.', self::class, self::class));
+			throw new NumberFormatException(sprintf('You can set only %s for %s compound denominator.', self::class, self::class));
 		} else {
 			$this->denominator = BigDecimal::of((string) $denominator);
 		}

--- a/src/Entity/Number.php
+++ b/src/Entity/Number.php
@@ -1,0 +1,333 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mathematicator\Numbers\Entity;
+
+
+use Brick\Math\BigDecimal;
+use Brick\Math\BigInteger;
+use Brick\Math\BigNumber;
+use Brick\Math\BigRational;
+use Brick\Math\Exception\DivisionByZeroException;
+use Brick\Math\Exception\NumberFormatException;
+use Brick\Math\Exception\RoundingNecessaryException;
+use Brick\Math\RoundingMode;
+use Mathematicator\Numbers\Converter\RationalToHumanString;
+use Mathematicator\Numbers\Converter\RationalToLatex;
+use Mathematicator\Numbers\Helper\NumberHelper;
+use Mathematicator\Numbers\HumanString\MathHumanStringBuilder;
+use Mathematicator\Numbers\HumanString\MathHumanStringToolkit;
+use Mathematicator\Numbers\Latex\MathLatexBuilder;
+use Mathematicator\Numbers\Latex\MathLatexToolkit;
+use Nette\SmartObject;
+
+/**
+ * Number is an entity for interpreting numbers with an arbitrary precision.
+ * Instance of Number is immutable (readonly since initialized). If you want to modify it,
+ * create a new one by new Number(...)
+ *
+ * The class can store the following data types:
+ * - Integer
+ * - Decimal number
+ * - Rational number
+ *
+ * @property-read int|float|string|BigNumber $input
+ * @property-read BigNumber $number
+ */
+class Number
+{
+	use SmartObject;
+
+	/**
+	 * Number main storage
+	 * @var BigNumber
+	 */
+	protected $_number;
+
+	/**
+	 * Original user input
+	 * @var int|float|string|BigNumber
+	 */
+	private $input;
+
+	/** @var mixed[] */
+	private $cache = [];
+
+
+	/**
+	 * @param int|float|string|BigNumber|Number $number
+	 * Allowed formats are: 123456789, 12345.6789, 5/8
+	 * If you have a real user input in nonstandard format, please NumberHelper::preprocessInput method first
+	 * @throws \Mathematicator\Numbers\Exception\NumberFormatException
+	 */
+	public function __construct($number)
+	{
+		$this->invalidateCache(); // Defines array cache indexes
+
+		if ($number instanceof self) {
+			$this->input = $number->getInput();
+			$this->_number = $number->getNumber();
+		} else {
+			$this->input = $number;
+			$this->setValue($number);
+		}
+	}
+
+
+	/**
+	 * @param int|float|string|BigNumber|Number $number
+	 * @return self
+	 */
+	public static function of($number)
+	{
+		return new self($number);
+	}
+
+
+	/**
+	 * Returns number in same type as stored
+	 *
+	 * @return BigNumber
+	 */
+	public function getNumber(): BigNumber
+	{
+		return $this->_number;
+	}
+
+
+	/**
+	 * User real input
+	 *
+	 * @return int|float|string|BigNumber
+	 */
+	public function getInput()
+	{
+		return $this->input;
+	}
+
+
+	/**
+	 * @param int $roundingMode
+	 * @return int
+	 */
+	public function toInt(int $roundingMode = RoundingMode::FLOOR): int
+	{
+		return $this->toBigInteger($roundingMode)->toInt();
+	}
+
+
+	/**
+	 * WARNING! Float is only an approximation. Float data type is not precise!
+	 * Always use getDecimal() method for precise computing.
+	 *
+	 * @param int $rationalScaleLimit Limit scale if rounding is needed (rational numbers). Default: 10
+	 * @param int $rationalRoundingMode Rounding mode for rational numbers
+	 * @return float
+	 */
+	public function toFloat(int $rationalScaleLimit = 10, int $rationalRoundingMode = RoundingMode::FLOOR): float
+	{
+		$cacheKey = $rationalScaleLimit . '_' . $rationalRoundingMode;
+		if (isset($this->cache['float'][$cacheKey])) {
+			return $this->cache['float'][$cacheKey];
+		} else {
+			return $this->cache['float'][$cacheKey] = $this->toBigDecimal($rationalScaleLimit, $rationalRoundingMode)->toFloat();
+		}
+	}
+
+
+	/**
+	 * @param int $roundingMode
+	 * @return BigInteger
+	 * @throws RoundingNecessaryException
+	 */
+	public function toBigInteger(int $roundingMode = RoundingMode::FLOOR): BigInteger
+	{
+		return $this->_number->toScale(0, $roundingMode)->toBigInteger();
+	}
+
+
+	/**
+	 * @param int $rationalScaleLimit Limit scale if rounding is needed (rational numbers). Default: 10
+	 * @param int $rationalRoundingMode Rounding mode for rational numbers
+	 * @return BigDecimal
+	 */
+	public function toBigDecimal(int $rationalScaleLimit = 10, int $rationalRoundingMode = RoundingMode::FLOOR): BigDecimal
+	{
+		$cacheKey = $rationalScaleLimit . '_' . $rationalRoundingMode;
+		if (isset($this->cache['decimal'][$cacheKey])) {
+			return $this->cache['decimal'][$cacheKey];
+		} else {
+			if ($this->_number instanceof BigRational) {
+				$result = (string) $this->_number->getNumerator()->toBigDecimal()
+					->dividedBy($this->_number->getDenominator(), $rationalScaleLimit, $rationalRoundingMode);
+				return BigDecimal::of(NumberHelper::removeTrailingZeros($result));
+			}
+
+			return $this->cache['decimal'][$cacheKey] = $this->_number->toBigDecimal();
+		}
+	}
+
+
+	/**
+	 * Returns simple rational number (similar to getFraction() but
+	 * without ArrayAccess and advance features).
+	 * TIP: Use toBigRational(false) for faster first result (returns not simplified rational number)
+	 *
+	 * @param bool|null $simplify Simplify rational number output (null means to not simplify rational input, else simplify)
+	 * @return BigRational
+	 */
+	public function toBigRational(?bool $simplify = null): BigRational
+	{
+		$simplify = ($simplify === true || ($simplify === null && !($this->_number instanceof BigRational)));
+
+		if ($simplify) {
+			return $this->toBigRationalSimplified();
+		}
+
+		if ($this->cache['rational']) {
+			return $this->cache['rational'];
+		} elseif ($this->_number instanceof BigRational) {
+			return $this->cache['rational'] = $this->_number;
+		} else {
+			return $this->cache['rational'] = $this->_number->toBigRational();
+		}
+	}
+
+
+	/**
+	 * Return number converted to fraction.
+	 * For example `2.5` will be converted to `[5, 2]`.
+	 * The fraction is always shortened to the basic shape.
+	 * TIP: Use toBigRational() method instead for faster first result (limited functionality)
+	 *
+	 * @param bool $simplify Simplify fraction on output (null means to not simplify rational input, else simplify)
+	 * @return FractionNumbersOnly
+	 */
+	public function toFraction(?bool $simplify = null): FractionNumbersOnly
+	{
+		$simplify = ($simplify === true || ($simplify === null && !($this->_number instanceof BigRational)));
+
+		if ($this->cache[$simplify ? 'fractionSimplified' : 'fraction']) {
+			return clone $this->cache[$simplify ? 'fractionSimplified' : 'fraction'];
+		}
+
+		$rationalNumber = $this->toBigRational($simplify);
+		return clone($this->cache[$simplify ? 'fractionSimplified' : 'fraction'] = new FractionNumbersOnly($rationalNumber->getNumerator(), $rationalNumber->getDenominator()));
+	}
+
+
+	/**
+	 * Returns a number in computer readable form (in LaTeX format).
+	 *
+	 * @return MathLatexBuilder
+	 */
+	public function toLatex(): MathLatexBuilder
+	{
+		if ($this->cache['latex'] !== null) {
+			return $this->cache['latex'];
+		} elseif ($this->_number instanceof BigRational) {
+			return $this->cache['latex'] = RationalToLatex::convert($this->toBigRational(false));
+		} elseif ($this->_number instanceof BigDecimal) {
+			return $this->cache['latex'] = MathLatexToolkit::create((string) $this->_number);
+		} else {
+			return $this->cache['latex'] = MathLatexToolkit::create((string) $this->_number);
+		}
+	}
+
+
+	/**
+	 * Returns a number in human readable form (valid SmartNumber input).
+	 *
+	 * @return MathHumanStringBuilder
+	 */
+	public function toHumanString(): MathHumanStringBuilder
+	{
+		if ($this->cache['humanString'] !== null) {
+			return $this->cache['humanString'];
+		} elseif ($this->_number instanceof BigRational) {
+			return $this->cache['humanString'] = RationalToHumanString::convert($this->toBigRational(false));
+		} else {
+			return $this->cache['humanString'] = MathHumanStringToolkit::create((string) $this->_number);
+		}
+	}
+
+
+	/**
+	 * Detects that the number passed is integer.
+	 * Advanced methods through fractional truncation are used for detection.
+	 *
+	 * @return bool
+	 */
+	public function isInteger(): bool
+	{
+		try {
+			$this->_number->toScale(0);
+			return true;
+		} catch (RoundingNecessaryException $e) {
+		}
+		return false;
+	}
+
+
+	/**
+	 * Returns number represented by string (valid SmartNumber input)
+	 *
+	 * @return string
+	 */
+	public function __toString(): string
+	{
+		return (string) $this->toHumanString();
+	}
+
+
+	/**
+	 * @param int|float|string|BigNumber $input
+	 * @throws \Mathematicator\Numbers\Exception\NumberFormatException
+	 * @throws \Mathematicator\Numbers\Exception\DivisionByZeroException
+	 */
+	protected function setValue($input): void
+	{
+		try {
+			$this->_number = BigNumber::of($input);
+		} catch (NumberFormatException $e) {
+			throw new \Mathematicator\Numbers\Exception\NumberFormatException($e->getMessage());
+		} catch (DivisionByZeroException $e) {
+			throw new \Mathematicator\Numbers\Exception\DivisionByZeroException($e->getMessage());
+		}
+	}
+
+
+	/**
+	 * Invalidates internal cache used for faster reading.
+	 */
+	protected function invalidateCache(): void
+	{
+		$this->cache = [
+			'float' => null,
+			'fraction' => null,
+			'fractionSimplified' => null,
+			'humanString' => null,
+			'latex' => null,
+			'rational' => null,
+			'rationalSimplified' => null,
+		];
+	}
+
+
+	/**
+	 * Returns rational number in normal form
+	 *
+	 * @return BigRational
+	 */
+	private function toBigRationalSimplified(): BigRational
+	{
+		if ($this->cache['rationalSimplified']) {
+			return $this->cache['rationalSimplified'];
+		} elseif ($this->_number instanceof BigRational) {
+			return $this->cache['rationalSimplified'] = $this->_number->simplified();
+		} else {
+			return $this->cache['rationalSimplified'] = $this->_number->toBigRational()->simplified();
+		}
+	}
+}

--- a/src/Exception/DivisionByZeroException.php
+++ b/src/Exception/DivisionByZeroException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mathematicator\Numbers\Exception;
+
+/**
+ * Exception thrown when a division by zero occurs.
+ */
+class DivisionByZeroException extends NumberException
+{
+	/**
+	 * @param string $x
+	 * @param string $y
+	 * @throws NumberException
+	 */
+	public static function canNotDivisionFractionByZero(string $x, string $y): void
+	{
+		throw new self('Can not division fraction [' . $x . ' / ' . $y . '] by zero.');
+	}
+}

--- a/src/Exception/NumberException.php
+++ b/src/Exception/NumberException.php
@@ -5,28 +5,6 @@ declare(strict_types=1);
 namespace Mathematicator\Numbers\Exception;
 
 
-use Exception;
-
-final class NumberException extends Exception
+abstract class NumberException extends \RuntimeException
 {
-
-	/**
-	 * @param string $haystack
-	 * @throws NumberException
-	 */
-	public static function invalidInput(string $haystack): void
-	{
-		throw new self('Invalid input format, because haystack "' . $haystack . '" given.');
-	}
-
-
-	/**
-	 * @param string $x
-	 * @param string $y
-	 * @throws NumberException
-	 */
-	public static function canNotDivisionFractionByZero(string $x, string $y): void
-	{
-		throw new self('Can not division fraction [' . $x . ' / ' . $y . '] by zero.');
-	}
 }

--- a/src/Exception/NumberFormatException.php
+++ b/src/Exception/NumberFormatException.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mathematicator\Numbers\Exception;
+
+/**
+ * Exception thrown when invalid number format on input is provided.
+ */
+class NumberFormatException extends NumberException
+{
+
+	/**
+	 * @param string $haystack
+	 * @throws NumberFormatException
+	 */
+	public static function invalidInput(string $haystack): void
+	{
+		throw new self('Invalid input format, because haystack "' . $haystack . '" given.');
+	}
+}

--- a/src/Exception/UnsupportedCalcOperationException.php
+++ b/src/Exception/UnsupportedCalcOperationException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mathematicator\Numbers\Exception;
+
+class UnsupportedCalcOperationException extends NumberException
+{
+}

--- a/src/Helper/FractionHelper.php
+++ b/src/Helper/FractionHelper.php
@@ -10,7 +10,8 @@ use Brick\Math\Exception\RoundingNecessaryException;
 use Brick\Math\RoundingMode;
 use Mathematicator\Numbers\Converter\DecimalToFraction;
 use Mathematicator\Numbers\Entity\FractionNumbersOnly;
-use Mathematicator\Numbers\Exception\NumberException;
+use Mathematicator\Numbers\Exception\DivisionByZeroException;
+use Mathematicator\Numbers\Exception\NumberFormatException;
 use Mathematicator\Numbers\PrimaryNumber;
 use Nette\StaticClass;
 use Nette\Utils\Validators;
@@ -28,7 +29,7 @@ class FractionHelper
 	 * @param int $level
 	 * @param int $maxLevel
 	 * @return FractionNumbersOnly
-	 * @throws NumberException
+	 * @throws NumberFormatException
 	 */
 	public static function toShortenForm(FractionNumbersOnly $fraction, int $level = 0, int $maxLevel = 100): FractionNumbersOnly
 	{
@@ -49,7 +50,7 @@ class FractionHelper
 		}
 
 		if ($denominatorValue->isEqualTo(0)) {
-			NumberException::canNotDivisionFractionByZero((string) $numeratorValue, (string) $denominatorValue);
+			DivisionByZeroException::canNotDivisionFractionByZero((string) $numeratorValue, (string) $denominatorValue);
 		}
 
 		$fractionValue = self::evaluate($fraction);
@@ -105,13 +106,13 @@ class FractionHelper
 	 * @param int|null $scale
 	 * @param int $roundingMode
 	 * @return BigDecimal
-	 * @throws NumberException
+	 * @throws NumberFormatException
 	 * @todo Change scale to arbitrary using math expression
 	 */
 	public static function evaluate(FractionNumbersOnly $fraction, ?int $scale = 100, int $roundingMode = RoundingMode::FLOOR): BigDecimal
 	{
 		if (!$fraction->isValid()) {
-			throw new NumberException('Cannot enumerate fraction without numerator.');
+			throw new NumberFormatException('Cannot enumerate fraction without numerator.');
 		}
 
 		/** @var FractionNumbersOnly|BigDecimal $numerator */

--- a/src/SmartNumber.php
+++ b/src/SmartNumber.php
@@ -6,273 +6,37 @@ namespace Mathematicator\Numbers;
 
 
 use Brick\Math\BigDecimal;
-use Brick\Math\BigInteger;
 use Brick\Math\BigNumber;
 use Brick\Math\BigRational;
-use Brick\Math\Exception\DivisionByZeroException;
-use Brick\Math\Exception\MathException;
-use Brick\Math\Exception\NumberFormatException;
-use Brick\Math\Exception\RoundingNecessaryException;
-use Brick\Math\RoundingMode;
-use Mathematicator\Numbers\Converter\RationalToHumanString;
-use Mathematicator\Numbers\Converter\RationalToLatex;
-use Mathematicator\Numbers\Entity\FractionNumbersOnly;
+use Mathematicator\Numbers\Entity\Number;
 use Mathematicator\Numbers\Helper\NumberHelper;
-use Mathematicator\Numbers\HumanString\MathHumanStringBuilder;
-use Mathematicator\Numbers\HumanString\MathHumanStringToolkit;
-use Mathematicator\Numbers\Latex\MathLatexBuilder;
-use Mathematicator\Numbers\Latex\MathLatexToolkit;
-use Nette\SmartObject;
 
 /**
- * This is an implementation of an easy-to-use entity for interpreting numbers.
+ * SmartNumber is an easy-to-use entity for interpreting numbers with some softly invalid inputs corrections
+ * and comparing features.
  * Instance of SmartNumber is immutable (readonly since initialized). If you want to modify it,
  * create a new one by new SmartNumber(...)
  *
  * The class can store the following data types:
- *
- * - Original user input
  * - Integer
- * - Decimal number with adjustable accuracy
- * - Fraction
+ * - Decimal number
+ * - Rational number
+ *
+ * Some methods decorates implementation from brick/math package.
  *
  * @property-read int|float|string|BigNumber $input
- * @property-read BigInteger $integer
- * @property-read float $float
- * @property-read BigDecimal $decimal
- * @property-read FractionNumbersOnly $fraction
- * @property-read BigRational $rational
- * @property-read string $string
- * @property-read MathLatexBuilder $latex
- * @property-read MathHumanStringBuilder $humanString
  * @property-read BigNumber $number
  */
-final class SmartNumber
+final class SmartNumber extends Number
 {
-	use SmartObject;
 
 	/**
-	 * Original user input
-	 * @var int|float|string|BigNumber
+	 * @param int|float|string|BigNumber|Number $number
+	 * @return self
 	 */
-	private $input;
-
-	/**
-	 * Number main storage
-	 * @var BigNumber
-	 */
-	private $number;
-
-	/** @var mixed[] */
-	private $cache = [];
-
-
-	/**
-	 * @param int|float|string|BigNumber $number
-	 * Allowed formats are: 123456789, 12345.6789, 5/8
-	 * If you have a real user input in nonstandard format, please NumberHelper::preprocessInput method first
-	 * @throws Exception\NumberFormatException
-	 */
-	public function __construct($number)
+	public static function of($number): self
 	{
-		$this->setValue($number);
-	}
-
-
-	/**
-	 * User real input
-	 *
-	 * @return int|float|string|BigNumber
-	 */
-	public function getInput()
-	{
-		return $this->input;
-	}
-
-
-	/**
-	 * @param int $roundingMode
-	 * @return BigInteger
-	 * @throws MathException If the number is too big and cannot be converted to a native integer.
-	 */
-	public function getInteger(int $roundingMode = RoundingMode::FLOOR): BigInteger
-	{
-		return $this->number->toScale(0, $roundingMode)->toBigInteger();
-	}
-
-
-	/**
-	 * WARNING! Float is only an approximation. Float data type is not precise!
-	 * Always use getDecimal() method for precise computing.
-	 *
-	 * @param int $rationalScaleLimit Limit scale if rounding is needed (rational numbers). Default: 10
-	 * @param int $rationalRoundingMode Rounding mode for rational numbers
-	 * @return float
-	 */
-	public function getFloat(int $rationalScaleLimit = 10, int $rationalRoundingMode = RoundingMode::FLOOR): float
-	{
-		$cacheKey = $rationalScaleLimit . '_' . $rationalRoundingMode;
-		if (isset($this->cache['float'][$cacheKey])) {
-			return $this->cache['float'][$cacheKey];
-		} else {
-			return $this->cache['float'][$cacheKey] = $this->getDecimal($rationalScaleLimit, $rationalRoundingMode)->toFloat();
-		}
-	}
-
-
-	/**
-	 * @param int $rationalScaleLimit Limit scale if rounding is needed (rational numbers). Default: 10
-	 * @param int $rationalRoundingMode Rounding mode for rational numbers
-	 * @return BigDecimal
-	 */
-	public function getDecimal(int $rationalScaleLimit = 10, int $rationalRoundingMode = RoundingMode::FLOOR): BigDecimal
-	{
-		$cacheKey = $rationalScaleLimit . '_' . $rationalRoundingMode;
-		if (isset($this->cache['decimal'][$cacheKey])) {
-			return $this->cache['decimal'][$cacheKey];
-		} else {
-			if ($this->number instanceof BigRational) {
-				$result = (string) $this->number->getNumerator()->toBigDecimal()
-					->dividedBy($this->number->getDenominator(), $rationalScaleLimit, $rationalRoundingMode);
-				return BigDecimal::of(NumberHelper::removeTrailingZeros($result));
-			}
-
-			return $this->cache['decimal'][$cacheKey] = $this->number->toBigDecimal();
-		}
-	}
-
-
-	/**
-	 * Return number converted to fraction.
-	 * For example `2.5` will be converted to `[5, 2]`.
-	 * The fraction is always shortened to the basic shape.
-	 * TIP: Use getRational() method instead for faster first result (limited functionality)
-	 *
-	 * @param bool $simplify Simplify fraction on output (null means to not simplify rational input, else simplify)
-	 * @return FractionNumbersOnly
-	 */
-	public function getFraction(?bool $simplify = null): FractionNumbersOnly
-	{
-		$simplify = ($simplify === true || ($simplify === null && !($this->number instanceof BigRational)));
-
-		if ($this->cache[$simplify ? 'fractionSimplified' : 'fraction']) {
-			return clone $this->cache[$simplify ? 'fractionSimplified' : 'fraction'];
-		}
-
-		$rationalNumber = $this->getRational($simplify);
-		return clone($this->cache[$simplify ? 'fractionSimplified' : 'fraction'] = new FractionNumbersOnly($rationalNumber->getNumerator(), $rationalNumber->getDenominator()));
-	}
-
-
-	/**
-	 * Returns number in same type as stored
-	 *
-	 * @return BigNumber
-	 */
-	public function getNumber(): BigNumber
-	{
-		return $this->number;
-	}
-
-
-	/**
-	 * Returns simple rational number (similar to getFraction() but
-	 * without ArrayAccess and advance features).
-	 * TIP: Use getRational(false) for faster first result (returns not simplified rational number)
-	 *
-	 * @param bool|null $simplify Simplify rational number output (null means to not simplify rational input, else simplify)
-	 * @return BigRational
-	 */
-	public function getRational(?bool $simplify = null): BigRational
-	{
-		$simplify = ($simplify === true || ($simplify === null && !($this->number instanceof BigRational)));
-
-		if ($simplify) {
-			return $this->getRationalSimplified();
-		}
-
-		if ($this->cache['rational']) {
-			return $this->cache['rational'];
-		} elseif ($this->number instanceof BigRational) {
-			return $this->cache['rational'] = $this->number;
-		} else {
-			return $this->cache['rational'] = $this->number->toBigRational();
-		}
-	}
-
-
-	/**
-	 * Detects that the number passed is integer.
-	 * Advanced methods through fractional truncation are used for detection.
-	 *
-	 * @return bool
-	 */
-	public function isInteger(): bool
-	{
-		try {
-			$this->number->toScale(0);
-			return true;
-		} catch (RoundingNecessaryException $e) {
-		}
-		return false;
-	}
-
-
-	/**
-	 * Returns number represented by string (valid SmartNumber input)
-	 *
-	 * @return string
-	 */
-	public function __toString(): string
-	{
-		return (string) $this->getHumanString();
-	}
-
-
-	/**
-	 * Returns a number in default form (in LaTeX format). Prefers fraction output.
-	 *
-	 * @return string
-	 */
-	public function getString(): string
-	{
-		return (string) $this;
-	}
-
-
-	/**
-	 * Returns a number in computer readable form (in LaTeX format).
-	 *
-	 * @return MathLatexBuilder
-	 */
-	public function getLatex(): MathLatexBuilder
-	{
-		if ($this->cache['latex'] !== null) {
-			return $this->cache['latex'];
-		} elseif ($this->number instanceof BigRational) {
-			return $this->cache['latex'] = RationalToLatex::convert($this->getRational(false));
-		} elseif ($this->number instanceof BigDecimal) {
-			return $this->cache['latex'] = MathLatexToolkit::create((string) $this->number);
-		} else {
-			return $this->cache['latex'] = MathLatexToolkit::create((string) $this->number);
-		}
-	}
-
-
-	/**
-	 * Returns a number in human readable form (valid SmartNumber input).
-	 *
-	 * @return MathHumanStringBuilder
-	 */
-	public function getHumanString(): MathHumanStringBuilder
-	{
-		if ($this->cache['humanString'] !== null) {
-			return $this->cache['humanString'];
-		} elseif ($this->number instanceof BigRational) {
-			return $this->cache['humanString'] = RationalToHumanString::convert($this->getRational(false));
-		} else {
-			return $this->cache['humanString'] = MathHumanStringToolkit::create((string) $this->number);
-		}
+		return new self($number);
 	}
 
 
@@ -283,7 +47,7 @@ final class SmartNumber
 	 */
 	public function isPositive(): bool
 	{
-		return $this->number->isPositive();
+		return $this->_number->isPositive();
 	}
 
 
@@ -294,7 +58,7 @@ final class SmartNumber
 	 */
 	public function isNegative(): bool
 	{
-		return $this->number->isNegative();
+		return $this->_number->isNegative();
 	}
 
 
@@ -305,7 +69,7 @@ final class SmartNumber
 	 */
 	public function isZero(): bool
 	{
-		return $this->number->isZero();
+		return $this->_number->isZero();
 	}
 
 
@@ -318,7 +82,7 @@ final class SmartNumber
 	 */
 	public function isEqualTo($that): bool
 	{
-		return $this->number->isEqualTo($that);
+		return $this->_number->isEqualTo($that);
 	}
 
 
@@ -331,7 +95,7 @@ final class SmartNumber
 	 */
 	public function isLessThan($that): bool
 	{
-		return $this->number->isLessThan($that);
+		return $this->_number->isLessThan($that);
 	}
 
 
@@ -344,7 +108,7 @@ final class SmartNumber
 	 */
 	public function isLessThanOrEqualTo($that): bool
 	{
-		return $this->number->isLessThanOrEqualTo($that);
+		return $this->_number->isLessThanOrEqualTo($that);
 	}
 
 
@@ -357,7 +121,7 @@ final class SmartNumber
 	 */
 	public function isGreaterThan($that): bool
 	{
-		return $this->number->isGreaterThan($that);
+		return $this->_number->isGreaterThan($that);
 	}
 
 
@@ -370,24 +134,7 @@ final class SmartNumber
 	 */
 	public function isGreaterThanOrEqualTo($that): bool
 	{
-		return $this->number->isGreaterThanOrEqualTo($that);
-	}
-
-
-	/**
-	 * Returns rational number in normal form
-	 *
-	 * @return BigRational
-	 */
-	private function getRationalSimplified(): BigRational
-	{
-		if ($this->cache['rationalSimplified']) {
-			return $this->cache['rationalSimplified'];
-		} elseif ($this->number instanceof BigRational) {
-			return $this->cache['rationalSimplified'] = $this->number->simplified();
-		} else {
-			return $this->cache['rationalSimplified'] = $this->number->toBigRational()->simplified();
-		}
+		return $this->_number->isGreaterThanOrEqualTo($that);
 	}
 
 
@@ -399,16 +146,13 @@ final class SmartNumber
 	 * @param int|float|string|BigNumber $input
 	 * @throws Exception\NumberFormatException
 	 */
-	private function setValue($input): void
+	protected function setValue($input): void
 	{
-		$this->invalidateCache(); // Defines array cache indexes
-		$this->input = $input;
-
 		try {
-			$this->setValueDirectly($input);
+			parent::setValue($input);
 			return;
-		} catch (NumberFormatException $e) {
-		} catch (DivisionByZeroException $e) {
+		} catch (Exception\NumberFormatException $e) {
+		} catch (Exception\DivisionByZeroException $e) {
 			throw new Exception\DivisionByZeroException($e->getMessage());
 		}
 
@@ -416,9 +160,9 @@ final class SmartNumber
 		$input = NumberHelper::preprocessInput((string) $input, ['.'], ['', ' ']);
 
 		try {
-			$this->setValueDirectly($input);
+			parent::setValue($input);
 			return;
-		} catch (NumberFormatException $e) {
+		} catch (Exception\NumberFormatException $e) {
 		}
 
 		// Solve multiple positivity signs (e.g. --6 => 6, ---5 => -5, --5.2 => 5.2, --5/2 => 5/2)
@@ -434,37 +178,10 @@ final class SmartNumber
 
 			$multiplier = 10 * (($numerator->getScale() > $denominator->getScale()) ? $numerator->getScale() : $denominator->getScale());
 
-			$this->number = BigRational::nd($parseResult[1] * $multiplier, $parseResult[2] * $multiplier);
+			$this->_number = BigRational::nd($parseResult[1] * $multiplier, $parseResult[2] * $multiplier);
 			return;
 		}
 
 		Exception\NumberFormatException::invalidInput($input);
-	}
-
-
-	/**
-	 * @param int|float|string|BigNumber $input
-	 * @throws NumberFormatException
-	 */
-	private function setValueDirectly($input): void
-	{
-		$this->number = BigNumber::of($input);
-	}
-
-
-	/**
-	 * Invalidates internal cache used for faster reading.
-	 */
-	private function invalidateCache(): void
-	{
-		$this->cache = [
-			'float' => null,
-			'fraction' => null,
-			'fractionSimplified' => null,
-			'humanString' => null,
-			'latex' => null,
-			'rational' => null,
-			'rationalSimplified' => null,
-		];
 	}
 }

--- a/tests/NumbersTests/Entity/CalculationTest.php
+++ b/tests/NumbersTests/Entity/CalculationTest.php
@@ -6,7 +6,7 @@ namespace Mathematicator\Numbers\Tests\Entity;
 
 
 use Brick\Math\RoundingMode;
-use Mathematicator\Numbers\Entity\Calculation;
+use Mathematicator\Numbers\Calculation;
 use Mathematicator\Numbers\Entity\Number;
 use Tester\Assert;
 use Tester\TestCase;

--- a/tests/NumbersTests/Entity/CalculationTest.php
+++ b/tests/NumbersTests/Entity/CalculationTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mathematicator\Numbers\Tests\Entity;
+
+
+use Brick\Math\RoundingMode;
+use Mathematicator\Numbers\Entity\Calculation;
+use Mathematicator\Numbers\Entity\Number;
+use Tester\Assert;
+use Tester\TestCase;
+
+require_once __DIR__ . '/../../Bootstrap.php';
+
+class CalculationTest extends TestCase
+{
+	public function testDecimal2(): void
+	{
+		$number = Number::of('80.500');
+
+		// Operations
+		Assert::same('322.000', (string) Calculation::of($number)->multipliedBy(4));
+		Assert::same('-322.000', (string) Calculation::of($number)->multipliedBy(-4));
+		Assert::same(322, Calculation::of($number)->multipliedBy(4)->abs()->getResult()->toBigInteger()->toInt());
+	}
+
+
+	public function testReadmeExample(): void
+	{
+		$number = Number::of('80.500');
+		Assert::same('80.500', (string) $number->toBigDecimal());
+		Assert::same('161', (string) $number->toFraction()->getNumerator());
+		Assert::same('2', (string) $number->toFraction()->getDenominator());
+		Assert::same('-322.000', (string) Calculation::of($number)->multipliedBy(-4));
+		Assert::same('322', (string) Calculation::of($number)->multipliedBy(-4)->abs()->getResult()->toBigInteger()->toInt());
+		Assert::same('81', (string) $number->toBigDecimal()->toScale(0, RoundingMode::HALF_UP));
+
+		$number2 = Number::of('161/2');
+		Assert::same('161/2', (string) $number2->toHumanString());
+		Assert::same('161/2+5=90.5', (string) $number2->toHumanString()->plus(5)->equals('90.5'));
+		Assert::same('\frac{161}{2}', (string) $number2->toLatex());
+		Assert::same('80.5', (string) $number2->toBigDecimal());
+	}
+}
+
+(new CalculationTest())->run();

--- a/tests/NumbersTests/Entity/NumberTest.php
+++ b/tests/NumbersTests/Entity/NumberTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mathematicator\Numbers\Tests\Entity;
+
+
+use Brick\Math\RoundingMode;
+use InvalidArgumentException;
+use Mathematicator\Numbers\Entity\Number;
+use Mathematicator\Numbers\Exception\DivisionByZeroException;
+use Mathematicator\Numbers\Exception\NumberFormatException;
+use Mathematicator\Numbers\Helper\NumberHelper;
+use Tester\Assert;
+use Tester\TestCase;
+
+require_once __DIR__ . '/../../Bootstrap.php';
+
+class NumberTest extends TestCase
+{
+	public function testInt(): void
+	{
+		$number = Number::of('10');
+		Assert::same('10', (string) $number->toBigInteger());
+	}
+
+
+	public function testDecimal(): void
+	{
+		$number = Number::of('10.125');
+		Assert::same('10', (string) $number->toBigInteger());
+		Assert::same(10.125, $number->toFloat());
+		Assert::same('10.125', (string) $number->toBigDecimal());
+	}
+
+
+	public function testDecimal2(): void
+	{
+		$number = Number::of('80.500');
+
+		// Fractions
+		Assert::same('161', (string) $number->toFraction()->getNumerator());
+		Assert::same('2', (string) $number->toFraction()->getDenominator());
+
+		// Outputs
+		Assert::same(80.5, $number->toFloat());
+		Assert::same('80', (string) $number->toBigInteger());
+		Assert::same('80.500', (string) $number->toHumanString());
+		Assert::same('161/2', (string) $number->toFraction());
+		Assert::same('80.500', (string) $number);
+		Assert::same('80.500', (string) $number->toLatex());
+
+		// Operations
+		Assert::same('322.000', (string) $number->toBigDecimal()->multipliedBy(4));
+		Assert::same('-322.000', (string) $number->toBigDecimal()->multipliedBy(-4));
+		Assert::same(322, $number->toBigDecimal()->multipliedBy(4)->abs()->toInt());
+	}
+
+
+	public function testPreFormattingWithCustomSeparators(): void
+	{
+		$number = Number::of(NumberHelper::preprocessInput('10x000a80g500', ['g', '.'], ['', 'a', 'x', 'd']));
+		Assert::same('1000080.5', (string) $number->toBigDecimal());
+		Assert::same('1000081', (string) $number->toBigDecimal()->toScale(0, RoundingMode::HALF_UP));
+	}
+
+
+	/**
+	 * @throws InvalidArgumentException
+	 */
+	public function testPreFormattingWithCustomSeparators2(): void
+	{
+		$number = Number::of(NumberHelper::preprocessInput('10x000a80g500', ['g', 1], ['', 'a', 'x', 'd']));
+	}
+
+
+	public function testFractionPropertyClonability(): void
+	{
+		$number = Number::of('1000080.500');
+		$fraction = $number->toFraction();
+		Assert::same('2000161/2', (string) $number->toFraction());
+
+		$newFraction = $fraction->setNumerator(1);
+		Assert::same('2000161/2', (string) $number->toFraction());
+		Assert::same('1/2', (string) $newFraction);
+		Assert::same('1', (string) $newFraction->getNumerator());
+	}
+
+
+	public function testReadmeExample(): void
+	{
+		$number = Number::of('80.500');
+		Assert::same('80.500', (string) $number->toBigDecimal());
+		Assert::same('161', (string) $number->toFraction()->getNumerator());
+		Assert::same('2', (string) $number->toFraction()->getDenominator());
+		Assert::same('-322.000', (string) $number->toBigDecimal()->multipliedBy(-4));
+		Assert::same('322', (string) $number->toBigDecimal()->multipliedBy(-4)->abs()->toInt());
+		Assert::same('81', (string) $number->toBigDecimal()->toScale(0, RoundingMode::HALF_UP));
+
+		$number2 = Number::of('161/2');
+		Assert::same('161/2', (string) $number2->toHumanString());
+		Assert::same('161/2+5=90.5', (string) $number2->toHumanString()->plus(5)->equals('90.5'));
+		Assert::same('\frac{161}{2}', (string) $number2->toLatex());
+		Assert::same('80.5', (string) $number2->toBigDecimal());
+	}
+
+
+	public function testBenchmarkCases(): void
+	{
+		$number = Number::of('158985102');
+		Assert::same('158985102', (string) $number->toFraction()[0]);
+
+		$number = Number::of('1482002/10');
+		Assert::same('1482002', (string) $number->toFraction(false)->getNumerator());
+
+		$number = Number::of('1482002/10');
+		Assert::same('741001', (string) $number->toBigRational(true)->getNumerator());
+	}
+
+
+	public function testNonStandardInputs()
+	{
+		$number = Number::of('-100/25');
+		Assert::same('-100/25', (string) $number->toBigRational());
+		Assert::same('-4', (string) $number->toBigInteger());
+		$number = Number::of('+5');
+		Assert::same('5', (string) $number->toBigDecimal());
+		$number = Number::of('+10/2');
+		Assert::same('5', (string) $number->toBigDecimal());
+		$number = Number::of('3.12e+2');
+		Assert::same('312', (string) $number->toBigDecimal());
+		$number = Number::of('3.12e+2');
+		Assert::same('312', (string) $number->toBigDecimal());
+		$number = Number::of('312e-2');
+		Assert::same('3.12', (string) $number->toBigDecimal());
+		$number = Number::of('1.5E-10');
+		Assert::same('0.00000000015', (string) $number->toBigDecimal());
+		$number = Number::of('-1.5E-10');
+		Assert::same('-0.00000000015', (string) $number->toBigDecimal());
+		Assert::same('-1.5E-10', (string) $number->getInput());
+		$number = Number::of('3.0012e2');
+		Assert::same('300.12', (string) $number->toBigDecimal());
+	}
+
+
+	public function testInfDecNumberFromRational()
+	{
+		$number = Number::of('1/3');
+		Assert::same('0.333', (string) $number->toBigDecimal(3));
+		Assert::same('0.334', (string) $number->toBigDecimal(3, RoundingMode::UP));
+		Assert::same('0', (string) $number->toBigInteger());
+
+		$number = Number::of('4/3');
+		Assert::same('1', (string) $number->toBigInteger());
+	}
+
+
+	public function testDivisionByZero()
+	{
+		Assert::throws(function () {
+			return Number::of('4/0');
+		}, DivisionByZeroException::class);
+	}
+
+
+	public function testInvalidInputs()
+	{
+		Assert::throws(function () {
+			return Number::of('');
+		}, NumberFormatException::class);
+		Assert::throws(function () {
+			return Number::of('25....');
+		}, NumberFormatException::class);
+		Assert::throws(function () {
+			return Number::of('4.');
+		}, NumberFormatException::class);
+		Assert::throws(function () {
+			return Number::of('+4.');
+		}, NumberFormatException::class);
+		Assert::throws(function () {
+			return Number::of('++10/2');
+		}, NumberFormatException::class);
+		Assert::throws(function () {
+			return Number::of('-+10/2');
+		}, NumberFormatException::class);
+		Assert::throws(function () {
+			return Number::of('--10/2');
+		}, NumberFormatException::class);
+		Assert::throws(function () {
+			return Number::of('--(10/2)');
+		}, NumberFormatException::class);
+		Assert::throws(function () {
+			return Number::of('10.2/6.4');
+		}, NumberFormatException::class);
+		Assert::throws(function () {
+			return Number::of('foo');
+		}, NumberFormatException::class);
+	}
+}
+
+(new NumberTest())->run();

--- a/tests/NumbersTests/SmartNumberTest.php
+++ b/tests/NumbersTests/SmartNumberTest.php
@@ -7,6 +7,8 @@ namespace Mathematicator\Numbers\Tests;
 
 use Brick\Math\RoundingMode;
 use InvalidArgumentException;
+use Mathematicator\Numbers\Exception\DivisionByZeroException;
+use Mathematicator\Numbers\Exception\NumberFormatException;
 use Mathematicator\Numbers\Helper\NumberHelper;
 use Mathematicator\Numbers\SmartNumber;
 use Tester\Assert;
@@ -28,7 +30,7 @@ class SmartNumberTest extends TestCase
 		$smartNumber = new SmartNumber('10.125');
 		Assert::same('10', (string) $smartNumber->getInteger());
 		Assert::same(10.125, $smartNumber->getFloat());
-		Assert::same('10.125', $smartNumber->getFloatString());
+		Assert::same('10.125', (string) $smartNumber->getDecimal());
 	}
 
 
@@ -178,6 +180,22 @@ class SmartNumberTest extends TestCase
 
 		$smartNumber = new SmartNumber('4/3');
 		Assert::same('1', (string) $smartNumber->getInteger());
+	}
+
+
+	public function testDivisionByZero()
+	{
+		Assert::throws(function () {
+			return new SmartNumber('4/0');
+		}, DivisionByZeroException::class);
+	}
+
+
+	public function testBlankInput()
+	{
+		Assert::throws(function () {
+			return new SmartNumber('');
+		}, NumberFormatException::class);
 	}
 }
 

--- a/tests/NumbersTests/SmartNumberTest.php
+++ b/tests/NumbersTests/SmartNumberTest.php
@@ -7,6 +7,8 @@ namespace Mathematicator\Numbers\Tests;
 
 use Brick\Math\RoundingMode;
 use InvalidArgumentException;
+use Mathematicator\Numbers\Entity\Calculation;
+use Mathematicator\Numbers\Entity\Number;
 use Mathematicator\Numbers\Exception\DivisionByZeroException;
 use Mathematicator\Numbers\Exception\NumberFormatException;
 use Mathematicator\Numbers\Helper\NumberHelper;
@@ -20,23 +22,23 @@ class SmartNumberTest extends TestCase
 {
 	public function testInt(): void
 	{
-		$smartNumber = new SmartNumber('10');
-		Assert::same('10', (string) $smartNumber->getInteger());
+		$smartNumber = SmartNumber::of('10');
+		Assert::same('10', (string) $smartNumber->toBigInteger());
 	}
 
 
 	public function testDecimal(): void
 	{
-		$smartNumber = new SmartNumber('10.125');
-		Assert::same('10', (string) $smartNumber->getInteger());
-		Assert::same(10.125, $smartNumber->getFloat());
-		Assert::same('10.125', (string) $smartNumber->getDecimal());
+		$smartNumber = SmartNumber::of('10.125');
+		Assert::same('10', (string) $smartNumber->toBigInteger());
+		Assert::same(10.125, $smartNumber->toFloat());
+		Assert::same('10.125', (string) $smartNumber->toBigDecimal());
 	}
 
 
 	public function testDecimal2(): void
 	{
-		$smartNumber = new SmartNumber('80.500');
+		$smartNumber = SmartNumber::of('80.500');
 
 		// Positivity
 		Assert::same(true, $smartNumber->isPositive());
@@ -44,36 +46,36 @@ class SmartNumberTest extends TestCase
 		Assert::same(false, $smartNumber->isZero());
 
 		// Fractions
-		Assert::same('161', (string) $smartNumber->getFraction()->getNumerator());
-		Assert::same('2', (string) $smartNumber->getFraction()->getDenominator());
+		Assert::same('161', (string) $smartNumber->toFraction()->getNumerator());
+		Assert::same('2', (string) $smartNumber->toFraction()->getDenominator());
 
 		// Outputs
-		Assert::same(80.5, $smartNumber->getFloat());
-		Assert::same('80', (string) $smartNumber->getInteger());
-		Assert::same('80.500', (string) $smartNumber->getHumanString());
-		Assert::same('161/2', (string) $smartNumber->getFraction());
-		Assert::same('80.500', (string) $smartNumber->getString());
-		Assert::same('80.500', (string) $smartNumber->getLatex());
+		Assert::same(80.5, $smartNumber->toFloat());
+		Assert::same('80', (string) $smartNumber->toBigInteger());
+		Assert::same('80.500', (string) $smartNumber->toHumanString());
+		Assert::same('161/2', (string) $smartNumber->toFraction());
+		Assert::same('80.500', (string) $smartNumber);
+		Assert::same('80.500', (string) $smartNumber->toLatex());
 
 		// Operations
-		Assert::same('322.000', (string) $smartNumber->getDecimal()->multipliedBy(4));
-		Assert::same('-322.000', (string) $smartNumber->getDecimal()->multipliedBy(-4));
-		Assert::same(322, $smartNumber->getDecimal()->multipliedBy(4)->abs()->toInt());
+		Assert::same('322.000', (string) Calculation::of($smartNumber)->multipliedBy(4));
+		Assert::same('-322.000', (string) Calculation::of($smartNumber)->multipliedBy(-4));
+		Assert::same(322, Calculation::of($smartNumber)->multipliedBy(4)->abs()->getResult()->toInt());
 	}
 
 
 	public function testPreFormatting(): void
 	{
-		$smartNumber = new SmartNumber('10 000 80.500');
-		Assert::same('1000080.5', (string) $smartNumber->getDecimal());
+		$smartNumber = SmartNumber::of('10 000 80.500');
+		Assert::same('1000080.5', (string) $smartNumber->toBigDecimal());
 	}
 
 
 	public function testPreFormattingWithCustomSeparators(): void
 	{
-		$smartNumber = new SmartNumber(NumberHelper::preprocessInput('10x000a80g500', ['g', '.'], ['', 'a', 'x', 'd']));
-		Assert::same('1000080.5', (string) $smartNumber->getDecimal());
-		Assert::same('1000081', (string) $smartNumber->getDecimal()->toScale(0, RoundingMode::HALF_UP));
+		$smartNumber = SmartNumber::of(NumberHelper::preprocessInput('10x000a80g500', ['g', '.'], ['', 'a', 'x', 'd']));
+		Assert::same('1000080.5', (string) $smartNumber->toBigDecimal());
+		Assert::same('1000081', (string) $smartNumber->toBigDecimal()->toScale(0, RoundingMode::HALF_UP));
 	}
 
 
@@ -82,18 +84,18 @@ class SmartNumberTest extends TestCase
 	 */
 	public function testPreFormattingWithCustomSeparators2(): void
 	{
-		$smartNumber = new SmartNumber(NumberHelper::preprocessInput('10x000a80g500', ['g', 1], ['', 'a', 'x', 'd']));
+		$smartNumber = SmartNumber::of(NumberHelper::preprocessInput('10x000a80g500', ['g', 1], ['', 'a', 'x', 'd']));
 	}
 
 
 	public function testFractionPropertyClonability(): void
 	{
-		$smartNumber = new SmartNumber('10 000 80.500');
-		$fraction = $smartNumber->getFraction();
-		Assert::same('2000161/2', (string) $smartNumber->getFraction());
+		$smartNumber = SmartNumber::of('10 000 80.500');
+		$fraction = $smartNumber->toFraction();
+		Assert::same('2000161/2', (string) $smartNumber->toFraction());
 
 		$newFraction = $fraction->setNumerator(1);
-		Assert::same('2000161/2', (string) $smartNumber->getFraction());
+		Assert::same('2000161/2', (string) $smartNumber->toFraction());
 		Assert::same('1/2', (string) $newFraction);
 		Assert::same('1', (string) $newFraction->getNumerator());
 	}
@@ -101,92 +103,92 @@ class SmartNumberTest extends TestCase
 
 	public function testReadmeExample(): void
 	{
-		$smartNumber = new SmartNumber('80.500');
-		Assert::same('80.500', (string) $smartNumber->getDecimal());
-		Assert::same('161', (string) $smartNumber->getFraction()->getNumerator());
-		Assert::same('2', (string) $smartNumber->getFraction()->getDenominator());
-		Assert::same('-322.000', (string) $smartNumber->getDecimal()->multipliedBy(-4));
-		Assert::same('322', (string) $smartNumber->getDecimal()->multipliedBy(-4)->abs()->toInt());
-		Assert::same('81', (string) $smartNumber->getDecimal()->toScale(0, RoundingMode::HALF_UP));
+		$smartNumber = SmartNumber::of('80.500');
+		Assert::same('80.500', (string) $smartNumber->toBigDecimal());
+		Assert::same('161', (string) $smartNumber->toFraction()->getNumerator());
+		Assert::same('2', (string) $smartNumber->toFraction()->getDenominator());
+		Assert::same('-322.000', (string) Calculation::of($smartNumber)->multipliedBy(-4));
+		Assert::same('322', (string) Calculation::of($smartNumber)->multipliedBy(-4)->abs()->getResult()->toInt());
+		Assert::same('81', (string) $smartNumber->toBigDecimal()->toScale(0, RoundingMode::HALF_UP));
 
-		$smartNumber2 = new SmartNumber('161/2');
-		Assert::same('161/2', (string) $smartNumber2->getHumanString());
-		Assert::same('161/2+5=90.5', (string) $smartNumber2->getHumanString()->plus(5)->equals('90.5'));
-		Assert::same('\frac{161}{2}', (string) $smartNumber2->getLatex());
-		Assert::same('80.5', (string) $smartNumber2->getDecimal());
+		$smartNumber2 = SmartNumber::of('161/2');
+		Assert::same('161/2', (string) $smartNumber2->toHumanString());
+		Assert::same('161/2+5=90.5', (string) $smartNumber2->toHumanString()->plus(5)->equals('90.5'));
+		Assert::same('\frac{161}{2}', (string) $smartNumber2->toLatex());
+		Assert::same('80.5', (string) $smartNumber2->toBigDecimal());
 	}
 
 
 	public function testBenchmarkCases(): void
 	{
-		$smartNumber = new SmartNumber('158985102');
-		Assert::same('158985102', (string) $smartNumber->getFraction()[0]);
+		$smartNumber = SmartNumber::of('158985102');
+		Assert::same('158985102', (string) $smartNumber->toFraction()[0]);
 
-		$smartNumber = new SmartNumber('1482002/10');
-		Assert::same('1482002', (string) $smartNumber->getFraction(false)->getNumerator());
+		$smartNumber = SmartNumber::of('1482002/10');
+		Assert::same('1482002', (string) $smartNumber->toFraction(false)->getNumerator());
 
-		$smartNumber = new SmartNumber('1482002/10');
-		Assert::same('741001', (string) $smartNumber->getRational(true)->getNumerator());
+		$smartNumber = SmartNumber::of('1482002/10');
+		Assert::same('741001', (string) $smartNumber->toBigRational(true)->getNumerator());
 	}
 
 
 	public function testNonStandardInputs()
 	{
-		$smartNumber = new SmartNumber('25....');
-		Assert::same('25', (string) $smartNumber->getDecimal());
-		$smartNumber = new SmartNumber('4.');
-		Assert::same('4', (string) $smartNumber->getDecimal());
-		$smartNumber = new SmartNumber('-100/25');
-		Assert::same('-100/25', (string) $smartNumber->getRational());
-		Assert::same('-4', (string) $smartNumber->getInteger());
-		$smartNumber = new SmartNumber('+4.');
-		Assert::same('4', (string) $smartNumber->getDecimal());
-		$smartNumber = new SmartNumber('+5');
-		Assert::same('5', (string) $smartNumber->getDecimal());
-		$smartNumber = new SmartNumber('+10/2');
-		Assert::same('5', (string) $smartNumber->getDecimal());
-		$smartNumber = new SmartNumber('++10/2');
-		Assert::same('5', (string) $smartNumber->getDecimal());
-		$smartNumber = new SmartNumber('-+10/2');
-		Assert::same('-5', (string) $smartNumber->getDecimal());
-		$smartNumber = new SmartNumber('--10/2');
-		Assert::same('5', (string) $smartNumber->getDecimal());
-		$smartNumber = new SmartNumber('--(10/2)');
-		Assert::same('5', (string) $smartNumber->getDecimal());
-		$smartNumber = new SmartNumber('3.12e+2');
-		Assert::same('312', (string) $smartNumber->getDecimal());
-		$smartNumber = new SmartNumber('3.12e+2');
-		Assert::same('312', (string) $smartNumber->getDecimal());
-		$smartNumber = new SmartNumber('312e-2');
-		Assert::same('3.12', (string) $smartNumber->getDecimal());
-		$smartNumber = new SmartNumber('1.5E-10');
-		Assert::same('0.00000000015', (string) $smartNumber->getDecimal());
-		$smartNumber = new SmartNumber('-1.5E-10');
-		Assert::same('-0.00000000015', (string) $smartNumber->getDecimal());
+		$smartNumber = SmartNumber::of('25....');
+		Assert::same('25', (string) $smartNumber->toBigDecimal());
+		$smartNumber = SmartNumber::of('4.');
+		Assert::same('4', (string) $smartNumber->toBigDecimal());
+		$smartNumber = SmartNumber::of('-100/25');
+		Assert::same('-100/25', (string) $smartNumber->toBigRational());
+		Assert::same('-4', (string) $smartNumber->toBigInteger());
+		$smartNumber = SmartNumber::of('+4.');
+		Assert::same('4', (string) $smartNumber->toBigDecimal());
+		$smartNumber = SmartNumber::of('+5');
+		Assert::same('5', (string) $smartNumber->toBigDecimal());
+		$smartNumber = SmartNumber::of('+10/2');
+		Assert::same('5', (string) $smartNumber->toBigDecimal());
+		$smartNumber = SmartNumber::of('++10/2');
+		Assert::same('5', (string) $smartNumber->toBigDecimal());
+		$smartNumber = SmartNumber::of('-+10/2');
+		Assert::same('-5', (string) $smartNumber->toBigDecimal());
+		$smartNumber = SmartNumber::of('--10/2');
+		Assert::same('5', (string) $smartNumber->toBigDecimal());
+		$smartNumber = SmartNumber::of('--(10/2)');
+		Assert::same('5', (string) $smartNumber->toBigDecimal());
+		$smartNumber = SmartNumber::of('3.12e+2');
+		Assert::same('312', (string) $smartNumber->toBigDecimal());
+		$smartNumber = SmartNumber::of('3.12e+2');
+		Assert::same('312', (string) $smartNumber->toBigDecimal());
+		$smartNumber = SmartNumber::of('312e-2');
+		Assert::same('3.12', (string) $smartNumber->toBigDecimal());
+		$smartNumber = SmartNumber::of('1.5E-10');
+		Assert::same('0.00000000015', (string) $smartNumber->toBigDecimal());
+		$smartNumber = SmartNumber::of('-1.5E-10');
+		Assert::same('-0.00000000015', (string) $smartNumber->toBigDecimal());
 		Assert::same('-1.5E-10', (string) $smartNumber->getInput());
-		$smartNumber = new SmartNumber('3.0012e2');
-		Assert::same('300.12', (string) $smartNumber->getDecimal());
-		$smartNumber = new SmartNumber('10.2/6.4');
-		Assert::same('102/64', (string) $smartNumber->getRational());
+		$smartNumber = SmartNumber::of('3.0012e2');
+		Assert::same('300.12', (string) $smartNumber->toBigDecimal());
+		$smartNumber = SmartNumber::of('10.2/6.4');
+		Assert::same('102/64', (string) $smartNumber->toBigRational());
 	}
 
 
 	public function testInfDecNumberFromRational()
 	{
-		$smartNumber = new SmartNumber('1/3');
-		Assert::same('0.333', (string) $smartNumber->getDecimal(3));
-		Assert::same('0.334', (string) $smartNumber->getDecimal(3, RoundingMode::UP));
-		Assert::same('0', (string) $smartNumber->getInteger());
+		$smartNumber = SmartNumber::of('1/3');
+		Assert::same('0.333', (string) $smartNumber->toBigDecimal(3));
+		Assert::same('0.334', (string) $smartNumber->toBigDecimal(3, RoundingMode::UP));
+		Assert::same('0', (string) $smartNumber->toBigInteger());
 
-		$smartNumber = new SmartNumber('4/3');
-		Assert::same('1', (string) $smartNumber->getInteger());
+		$smartNumber = SmartNumber::of('4/3');
+		Assert::same('1', (string) $smartNumber->toBigInteger());
 	}
 
 
 	public function testDivisionByZero()
 	{
 		Assert::throws(function () {
-			return new SmartNumber('4/0');
+			return SmartNumber::of('4/0');
 		}, DivisionByZeroException::class);
 	}
 
@@ -194,8 +196,29 @@ class SmartNumberTest extends TestCase
 	public function testBlankInput()
 	{
 		Assert::throws(function () {
-			return new SmartNumber('');
+			return SmartNumber::of('');
 		}, NumberFormatException::class);
+	}
+
+
+	public function testCreateFromNumberEntity()
+	{
+		$smartNumber = SmartNumber::of(Number::of('1/3'));
+		Assert::same('0.333', (string) $smartNumber->toBigDecimal(3));
+		Assert::same('0.334', (string) $smartNumber->toBigDecimal(3, RoundingMode::UP));
+		Assert::same('0', (string) $smartNumber->toBigInteger());
+		Assert::same('0', (string) $smartNumber->toBigInteger());
+
+		$smartNumber = SmartNumber::of(Number::of('4/3'));
+		Assert::same('1', (string) $smartNumber->toBigInteger());
+
+		$number = Number::of('1.0');
+		$smartNumber = SmartNumber::of($number);
+		Assert::same('1', (string) $smartNumber->toBigInteger());
+		Assert::true($smartNumber instanceof SmartNumber);
+		Assert::true($smartNumber instanceof Number);
+		Assert::false($number instanceof SmartNumber);
+		Assert::true($number instanceof Number);
 	}
 }
 

--- a/tests/NumbersTests/SmartNumberTest.php
+++ b/tests/NumbersTests/SmartNumberTest.php
@@ -7,7 +7,7 @@ namespace Mathematicator\Numbers\Tests;
 
 use Brick\Math\RoundingMode;
 use InvalidArgumentException;
-use Mathematicator\Numbers\Entity\Calculation;
+use Mathematicator\Numbers\Calculation;
 use Mathematicator\Numbers\Entity\Number;
 use Mathematicator\Numbers\Exception\DivisionByZeroException;
 use Mathematicator\Numbers\Exception\NumberFormatException;


### PR DESCRIPTION
- getter for original SmartNumber data type
- removed deprecated SmartNumber methods
- added comparison decoration methods
- more concrete exceptions
- BC Break: Refactoring (split SmartNumber and Number, Calculator decorator)
- get... methods that are not getters, but modifies original object to new state renamed to to... like in brick/math, ::of(...) initialization for more simple notation and for immutability look